### PR TITLE
[#50] 지역 행정 정보 API 캐싱

### DIFF
--- a/closet-api/src/main/java/project/closet/weather/controller/WeatherController.java
+++ b/closet-api/src/main/java/project/closet/weather/controller/WeatherController.java
@@ -40,8 +40,7 @@ public class WeatherController implements WeatherApi {
         @RequestParam Double latitude
     ) {
         log.info("날씨 위치 정보 조회 요청: longitude={}, latitude={}", longitude, latitude);
-        WeatherAPILocation location = weatherService.getLocation(longitude, latitude);
-        return ResponseEntity.ok(location);
+        return ResponseEntity.ok(weatherService.getLocation(longitude, latitude));
     }
 
 }

--- a/closet-api/src/main/resources/application-dev.yaml
+++ b/closet-api/src/main/resources/application-dev.yaml
@@ -11,6 +11,10 @@ spring:
       hibernate:
         format_sql: true
         show_sql: false
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 logging:
   level:

--- a/closet-application/build.gradle
+++ b/closet-application/build.gradle
@@ -9,6 +9,7 @@ project(':closet-application') {
     dependencies {
         implementation project(':closet-domain')
         implementation project(':closet-infra')
+        implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
         implementation 'org.springframework.boot:spring-boot-starter-web'
         implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/closet-application/src/main/java/project/closet/service/waether/basic/BasicWeatherService.java
+++ b/closet-application/src/main/java/project/closet/service/waether/basic/BasicWeatherService.java
@@ -1,5 +1,7 @@
 package project.closet.service.waether.basic;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -13,10 +15,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.closet.api.AddressClient;
 import project.closet.api.response.KakaoAddressResponse;
+import project.closet.config.RedisConfig;
 import project.closet.service.dto.response.WeatherAPILocation;
 import project.closet.service.dto.response.WeatherDto;
 import project.closet.service.waether.WeatherService;
@@ -31,26 +36,41 @@ import project.closet.weatherlocation.WeatherLocationRepository;
 @RequiredArgsConstructor
 public class BasicWeatherService implements WeatherService {
     private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+    private static final String CACHE_PREFIX = "weather:location:";
 
+    private final RedisTemplate<String, Object> redisTemplate;
     private final AddressClient addressClient;
     private final WeatherRepository weatherRepository;
-    private final WeatherLocationRepository weatherLocationRepository;
-
     private final GeoGridConverter geoGridConverter;
+    private final ObjectMapper objectMapper;
 
     @Override
     public WeatherAPILocation getLocation(Double longitude, Double latitude) {
         log.info("위도 경도로 행정구역 반환 요청: longitude={}, latitude={}", longitude, latitude);
-        KakaoAddressResponse kakaoAddressResponse =
-            addressClient.requestAddressFromKakao(longitude, latitude);
         Grid grid = geoGridConverter.convert(latitude, longitude);
-        return new WeatherAPILocation(
+        String cacheKey = CACHE_PREFIX + grid.x() + ":" + grid.y();
+
+        Object cacheValue = redisTemplate.opsForValue().get(cacheKey);
+        if (cacheValue != null) {
+            log.info("Cache Hit for grid ({}, {})", grid.x(), grid.y());
+            return objectMapper.convertValue(cacheValue, WeatherAPILocation.class);
+        }
+
+        log.info("❌ Cache Miss for grid ({}, {}) - calling Kakao API", grid.x(), grid.y());
+        KakaoAddressResponse kakaoAddressResponse = addressClient.requestAddressFromKakao(longitude, latitude);
+
+        WeatherAPILocation location = new WeatherAPILocation(
             latitude,
             longitude,
             grid.x(),
             grid.y(),
             kakaoAddressResponse.getLocationNames()
         );
+
+        // 3️⃣ Redis에 저장 (TTL = 30분)
+        redisTemplate.opsForValue().set(cacheKey, location, Duration.ofMinutes(30));
+
+        return location;
     }
 
     // TODO 바로 전 날짜의 온도와 비교해서 온도 정보 반환

--- a/closet-application/src/main/java/project/closet/service/waether/basic/BasicWeatherService.java
+++ b/closet-application/src/main/java/project/closet/service/waether/basic/BasicWeatherService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.closet.api.AddressClient;
 import project.closet.api.response.KakaoAddressResponse;
+import project.closet.cache.RedisCacheService;
 import project.closet.config.RedisConfig;
 import project.closet.service.dto.response.WeatherAPILocation;
 import project.closet.service.dto.response.WeatherDto;
@@ -38,11 +39,10 @@ public class BasicWeatherService implements WeatherService {
     private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
     private static final String CACHE_PREFIX = "weather:location:";
 
-    private final RedisTemplate<String, Object> redisTemplate;
     private final AddressClient addressClient;
     private final WeatherRepository weatherRepository;
     private final GeoGridConverter geoGridConverter;
-    private final ObjectMapper objectMapper;
+    private final RedisCacheService cacheService;
 
     @Override
     public WeatherAPILocation getLocation(Double longitude, Double latitude) {
@@ -50,13 +50,13 @@ public class BasicWeatherService implements WeatherService {
         Grid grid = geoGridConverter.convert(latitude, longitude);
         String cacheKey = CACHE_PREFIX + grid.x() + ":" + grid.y();
 
-        Object cacheValue = redisTemplate.opsForValue().get(cacheKey);
+        WeatherAPILocation cacheValue = cacheService.get(cacheKey, WeatherAPILocation.class);
         if (cacheValue != null) {
-            log.info("Cache Hit for grid ({}, {})", grid.x(), grid.y());
-            return objectMapper.convertValue(cacheValue, WeatherAPILocation.class);
+            log.info("Cache Hit → {}", cacheKey);
+            return cacheValue;
         }
 
-        log.info("❌ Cache Miss for grid ({}, {}) - calling Kakao API", grid.x(), grid.y());
+        log.info("Cache Miss → Kakao API 호출");
         KakaoAddressResponse kakaoAddressResponse = addressClient.requestAddressFromKakao(longitude, latitude);
 
         WeatherAPILocation location = new WeatherAPILocation(
@@ -67,13 +67,10 @@ public class BasicWeatherService implements WeatherService {
             kakaoAddressResponse.getLocationNames()
         );
 
-        // 3️⃣ Redis에 저장 (TTL = 30분)
-        redisTemplate.opsForValue().set(cacheKey, location, Duration.ofMinutes(30));
-
+        cacheService.set(cacheKey, location, Duration.ofMinutes(30));
         return location;
     }
 
-    // TODO 바로 전 날짜의 온도와 비교해서 온도 정보 반환
     @Transactional(readOnly = true)
     @Override
     public List<WeatherDto> getWeatherInfo(Double longitude, Double latitude) {

--- a/closet-infra/src/main/java/project/closet/cache/RedisCacheService.java
+++ b/closet-infra/src/main/java/project/closet/cache/RedisCacheService.java
@@ -1,0 +1,25 @@
+package project.closet.cache;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RedisCacheService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public <T> T get(String key, Class<T> clazz) {
+        Object value = redisTemplate.opsForValue().get(key);
+        if (value == null) return null;
+        return objectMapper.convertValue(value, clazz);
+    }
+
+    public void set(String key, Object value, Duration ttl) {
+        redisTemplate.opsForValue().set(key, value, ttl);
+    }
+}

--- a/closet-infra/src/main/java/project/closet/config/RedisConfig.java
+++ b/closet-infra/src/main/java/project/closet/config/RedisConfig.java
@@ -1,0 +1,21 @@
+package project.closet.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
+    }
+}


### PR DESCRIPTION
  <!-- PR 생성 전 아래 내용을 확인하고 작성해주세요 -->

## 📌 PR 제목
지역 행정 정보 API 캐싱

## 🔗 관련 이슈 번호
close #50 

## 📝 변경 사항 요약

- Redis 설정
- GeoGrid 격자 캐싱
- `CacheService` 를 만들어서 관심사 분리

## ✅ 체크리스트

- [x] 코드 빌드 및 컴파일 통과
- [ ] 단위/통합 테스트 통과
- [ ] 문서/주석 업데이트 완료  

## 추가
`CacheManager`를 이용한 전역 캐싱(`@Cacheable`)을 사용하지 않은 이유는,
단순히 메서드 호출 단위로 결과를 캐싱하는 것이 아니라
요청으로 들어온 `위도(latitude)`와 `경도(longitude)` 값을 **GeoGrid 좌표(x, y) 로 변환한 뒤**,
이 좌표 단위로 세밀하게 캐싱하기 위해 **로우 레벨**(`RedisTemplate`) 방식으로 직접 캐싱 로직을 구현했기 때문이다.