### PR TITLE
[#52] Kakao API 요청에 Rate Limit 설정 추가

### DIFF
--- a/closet-application/src/main/java/project/closet/service/waether/basic/BasicWeatherService.java
+++ b/closet-application/src/main/java/project/closet/service/waether/basic/BasicWeatherService.java
@@ -1,6 +1,5 @@
 package project.closet.service.waether.basic;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -15,14 +14,11 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.closet.api.AddressClient;
 import project.closet.api.response.KakaoAddressResponse;
 import project.closet.cache.RedisCacheService;
-import project.closet.config.RedisConfig;
 import project.closet.service.dto.response.WeatherAPILocation;
 import project.closet.service.dto.response.WeatherDto;
 import project.closet.service.waether.WeatherService;
@@ -30,7 +26,6 @@ import project.closet.weather.GeoGridConverter;
 import project.closet.weather.GeoGridConverter.Grid;
 import project.closet.weather.entity.Weather;
 import project.closet.weather.repository.WeatherRepository;
-import project.closet.weatherlocation.WeatherLocationRepository;
 
 @Slf4j
 @Service

--- a/closet-infra/build.gradle
+++ b/closet-infra/build.gradle
@@ -17,5 +17,8 @@ project(':closet-infra') {
 
         // Cache
         implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+        // https://mvnrepository.com/artifact/com.bucket4j/bucket4j_jdk17-core
+        implementation("com.bucket4j:bucket4j_jdk17-core:8.15.0")
     }
 }

--- a/closet-infra/src/main/java/project/closet/api/KakaoAddressClient.java
+++ b/closet-infra/src/main/java/project/closet/api/KakaoAddressClient.java
@@ -1,5 +1,6 @@
 package project.closet.api;
 
+import io.github.bucket4j.Bucket;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,9 +24,15 @@ public class KakaoAddressClient implements AddressClient {
     private String kakaoApiKey;
 
     private final RestTemplate restTemplate;
+    private final Bucket kakaoApiBucket;
 
     @Override
     public KakaoAddressResponse requestAddressFromKakao(Double longitude, Double latitude) {
+
+        if (!kakaoApiBucket.tryConsume(1)) {
+            throw new RuntimeException();
+        }
+
         String url =
             "https://dapi.kakao.com/v2/local/geo/coord2regioncode.json?x="
                 + longitude
@@ -60,5 +67,6 @@ public class KakaoAddressClient implements AddressClient {
             log.error("Kakao API 호출 실패: {}", e.getMessage());
             throw new RuntimeException("Kakao 주소 API 호출 실패", e);
         }
+
     }
 }

--- a/closet-infra/src/main/java/project/closet/api/kakaoapi/KakaoAddressClient.java
+++ b/closet-infra/src/main/java/project/closet/api/kakaoapi/KakaoAddressClient.java
@@ -1,4 +1,4 @@
-package project.closet.api;
+package project.closet.api.kakaoapi;
 
 import io.github.bucket4j.Bucket;
 import java.util.List;
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
+import project.closet.api.AddressClient;
 import project.closet.api.response.KakaoAddressResponse;
 import project.closet.api.response.KakaoAddressResponse.Document;
 
@@ -30,7 +31,8 @@ public class KakaoAddressClient implements AddressClient {
     public KakaoAddressResponse requestAddressFromKakao(Double longitude, Double latitude) {
 
         if (!kakaoApiBucket.tryConsume(1)) {
-            throw new RuntimeException();
+            log.warn("[RateLimit] Kakao API 일일 또는 월간 호출 한도 초과");
+            throw new RateLimitExceededException("Kakao API 호출 한도를 초과했습니다.");
         }
 
         String url =

--- a/closet-infra/src/main/java/project/closet/api/kakaoapi/RateLimitExceededException.java
+++ b/closet-infra/src/main/java/project/closet/api/kakaoapi/RateLimitExceededException.java
@@ -1,0 +1,12 @@
+package project.closet.api.kakaoapi;
+
+public class RateLimitExceededException extends RuntimeException {
+
+    public RateLimitExceededException(String message) {
+        super(message);
+    }
+
+    public RateLimitExceededException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/closet-infra/src/main/java/project/closet/config/LocalBucketConfig.java
+++ b/closet-infra/src/main/java/project/closet/config/LocalBucketConfig.java
@@ -11,7 +11,7 @@ public class LocalBucketConfig {
     public static final int MONTHLY_TOKEN = 300_000;
     public static final int DAILY_TOKEN = 30_000;
 
-    @Bean
+    @Bean(name = "kakaoApiBucket")
     public Bucket bucket() {
         return Bucket.builder()
             .addLimit(limit -> limit

--- a/closet-infra/src/main/java/project/closet/config/LocalBucketConfig.java
+++ b/closet-infra/src/main/java/project/closet/config/LocalBucketConfig.java
@@ -1,0 +1,25 @@
+package project.closet.config;
+
+import io.github.bucket4j.Bucket;
+import java.time.Duration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LocalBucketConfig {
+
+    public static final int MONTHLY_TOKEN = 300_000;
+    public static final int DAILY_TOKEN = 30_000;
+
+    @Bean
+    public Bucket bucket() {
+        return Bucket.builder()
+            .addLimit(limit -> limit
+                .capacity(DAILY_TOKEN)
+                .refillIntervally(DAILY_TOKEN, Duration.ofDays(1)))
+            .addLimit(limit -> limit
+                .capacity(MONTHLY_TOKEN)
+                .refillIntervally(MONTHLY_TOKEN, Duration.ofDays(30)))
+            .build();
+    }
+}

--- a/closet-infra/src/test/java/project/closet/api/kakao/KakaoAddressClientTest.java
+++ b/closet-infra/src/test/java/project/closet/api/kakao/KakaoAddressClientTest.java
@@ -1,4 +1,4 @@
-package project.closet.api;
+package project.closet.api.kakao;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -17,6 +17,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.client.RestTemplate;
+import project.closet.api.kakaoapi.KakaoAddressClient;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {

--- a/closet-infra/src/test/java/project/closet/storage/AWSS3Test.java
+++ b/closet-infra/src/test/java/project/closet/storage/AWSS3Test.java
@@ -1,4 +1,4 @@
-package project.closet.domain.clothes.storage;
+package project.closet.storage;
 
 import java.io.FileInputStream;
 import java.io.IOException;


### PR DESCRIPTION

## 🔗 관련 이슈 번호
#52 

## 📝 변경 사항 요약
- `Bucket4j` 라이브러리 추가
- `BucketConfig` 설정
- `Kakao API` 호출 전 Rate Limit 검사

## ✅ 체크리스트

- [ ] 코드 빌드 및 컴파일 통과
- [ ] 단위/통합 테스트 통과
- [ ] 문서/주석 업데이트 완료  
